### PR TITLE
chore(package.json): change module type to common

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dragonchain-sdk",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Dragonchain SDK for Node",
   "license": "Apache-2.0",
   "homepage": "https://github.com/dragonchain-inc/dragonchain-sdk-node#readme",
@@ -20,7 +20,7 @@
     "email": "support@dragonchain.com"
   },
   "main": "lib/module/commonjs/index.js",
-  "module": "lib/module/esnext/index.js",
+  "module": "lib/module/commonjs/index.js",
   "jsnext:main": "lib/module/esnext/index.js",
   "types": "lib/types/index.d.ts",
   "engines": {


### PR DESCRIPTION
this version jump (0.0.1->0.0.3) is due to a manual NPM push. We should only release via this deployment pipeline to avoid this in the future.


This changes the default module type to commonjs. not exnext.