### PR TITLE
feat(dragonchainclient): adds createcutomcontractv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ These docs are auto-generated.
 
 * [constructor](https://node-sdk-docs.dragonchain.com/latest/classes/dragonchainclient.html#constructor)
 * [clearOverriddenCredentials](https://node-sdk-docs.dragonchain.com/latest/classes/dragonchainclient.html#clearOverriddenCredentials)
-* [createCustomContract](https://node-sdk-docs.dragonchain.com/latest/classes/dragonchainclient.html#createcustomcontract)
+* [createCustomContractV2](https://node-sdk-docs.dragonchain.com/latest/classes/dragonchainclient.html#createcustomcontractv2)
 * [createLibraryContract](https://node-sdk-docs.dragonchain.com/latest/classes/dragonchainclient.html#createlibrarycontract)
 * [createTransaction](https://node-sdk-docs.dragonchain.com/latest/classes/dragonchainclient.html#createtransaction)
 * [createBulkTransaction](https://node-sdk-docs.dragonchain.com/latest/classes/dragonchainclient.html#createbulktransaction)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dragonchain-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Dragonchain SDK for Node",
   "license": "Apache-2.0",
   "homepage": "https://github.com/dragonchain-inc/dragonchain-sdk-node#readme",

--- a/src/services/dragonchain-client/DragonchainClient.spec.ts
+++ b/src/services/dragonchain-client/DragonchainClient.spec.ts
@@ -254,6 +254,26 @@ describe('DragonchainClient', () => {
 
     })
 
+    describe('.createCustomContractV2', () => {
+      it('create custom contract successfully', async () => {
+        const customContractPayload: CustomContractCreationSchema = {
+          'version': '2',
+          'dcrn': 'SmartContract::L1::Create',
+          'name': 'name',
+          'sc_type': 'transaction',
+          'is_serial': true,
+          'custom_environment_variables': { 'banana': 'banana', 'apple': 'banana' },
+          'runtime': 'nodejs6.10',
+          'code': 'code',
+          'origin': 'custom'
+        }
+        await client.createCustomContractV2('name', false, 'nodejs8.10', 'code', 'transaction', {}, 'banana.main')
+        const obj = { ...expectedFetchOptions, body: JSON.stringify(customContractPayload) }
+        assert.calledWith(fetch, `https://fakeDragonchainId.api.dragonchain.com/contract/name`, obj)
+      })
+
+    })
+
   })
 
   describe('PUT', () => {

--- a/src/services/dragonchain-client/DragonchainClient.ts
+++ b/src/services/dragonchain-client/DragonchainClient.ts
@@ -330,7 +330,36 @@ export class DragonchainClient {
    * @returns {Promise<DragonchainContractCreateResponse>}
    */
   public createCustomContract = async (body: CustomContractCreationSchema) => {
+    console.warn('Deprecation Notice. Support for createCustomContract will be phased out in v1.1.0. Please use "createCustomContractV2"')
     return await this.post(`/contract/${body.name}`, body) as Response<DragonchainContractCreateResponse>
+  }
+
+  /**
+   * Create a new Smart Contract on your Dragonchain.
+   * Create a new custom smart contract on your dragonchain
+   * @returns {Promise<DragonchainContractCreateResponse>}
+   */
+  public createCustomContractV2 = async (
+    name: string,
+    isSerial: boolean,
+    runtime: ContractRuntime,
+    code: string,
+    scType: SmartContractType = 'transaction',
+    customEnvironmentVariables: object = {},
+    handler: string = 'handler.main'
+  ) => {
+    return await this.post(`/contract/${name}`, {
+      'version': '2',
+      'dcrn': 'SmartContract::L1::Create',
+      'name': name,
+      'sc_type': scType,
+      'is_serial': isSerial,
+      'custom_environment_variables': customEnvironmentVariables,
+      'runtime': runtime,
+      'origin': 'custom',
+      'code': code,
+      'handler': handler
+    }) as Response<DragonchainContractCreateResponse>
   }
 
   /**


### PR DESCRIPTION
@Cosmos-it  Take a look at this update to the nodejs SDK. 

Instead of allowing users to submit a full `CustomContractCreationSchema` we lock them into version 2 of payloads and ask for params instead.

This is how python does it, and actually this is how the node SDK handles UpdateContract aswell.